### PR TITLE
Add resource-set and role attributes to Role model

### DIFF
--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -29773,6 +29773,10 @@ components:
           readOnly: true
         status:
           $ref: '#/components/schemas/LifecycleStatus'
+        resource-set:
+          type: string
+        role:
+          type: string
         type:
           $ref: '#/components/schemas/RoleType'
         _embedded:


### PR DESCRIPTION
## Issue(s)
Okta Java SDK is not deserializing `resource-set` and `role` attributes of custom roles in Role model.

## Description
Since [Fix deserialization of polymorphic types when discriminator property is unknown or null](https://github.com/okta/okta-sdk-java/pull/981) still in progress, attributes are added to Role model itself; however, then can be added to sub-class later on.

## Category
- [ ] Bugfix
- [X] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [X] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [X] I did not edit any automatically generated files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clementdenis/okta-sdk-java/2)
<!-- Reviewable:end -->
