### PR TITLE
Add CustomRole model for missing resource-set and role attributes

### DIFF
--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -24342,6 +24342,15 @@ components:
             type: string
           example:
             - 79496f234c814638b1cc44f51a782781
+    CustomRole:
+      allOf:
+        - $ref: '#/components/schemas/Role'
+        - type: object
+          properties:
+            resource-set:
+              type: string
+            role:
+              type: string
     DNSRecordType:
       example: TXT
       type: string
@@ -29783,6 +29792,10 @@ components:
           readOnly: true
         _links:
           $ref: '#/components/schemas/LinksSelf'
+      discriminator:
+        propertyName: type
+        mapping:
+          CUSTOM: '#/components/schemas/CustomRole'
     RoleAssignedUser:
       type: object
       properties:


### PR DESCRIPTION
## Issue(s)
Okta Java SDK is not deserializing `resource-set` and `role` attributes of custom roles in Role model.

## Description
First [Fix deserialization of polymorphic types when discriminator property is unknown or null](https://github.com/okta/okta-sdk-java/pull/981) should be completed. Custom Role model is added as subtype to Role model.

## Category
- [ ] Bugfix
- [X] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [X] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [X] I did not edit any automatically generated files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clementdenis/okta-sdk-java/3)
<!-- Reviewable:end -->
